### PR TITLE
feat: add more fields in ConfigPublish

### DIFF
--- a/configs.go
+++ b/configs.go
@@ -1,6 +1,8 @@
 package rabbitmq
 
 import (
+	"time"
+
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 
@@ -64,6 +66,13 @@ type ConfigPublish struct {
 	Priority        uint8
 	CorrelationID   string
 	MessageID       string
+	DeliveryMode    uint8
+	ReplyTo         string
+	Expiration      string
+	Timestamp       time.Time
+	Type            string
+	UserId          string
+	AppId           string
 }
 
 // NewConfigConsume helper function to create a new ConfigConsume with some default values

--- a/publish.go
+++ b/publish.go
@@ -27,6 +27,13 @@ func (r *rabbit) Publish(ctx context.Context, body []byte, config ConfigPublish)
 			CorrelationId:   config.CorrelationID,
 			MessageId:       config.MessageID,
 			Body:            body,
+			DeliveryMode:    config.DeliveryMode,
+			ReplyTo:         config.ReplyTo,
+			Expiration:      config.Expiration,
+			Timestamp:       config.Timestamp,
+			Type:            config.Type,
+			UserId:          config.UserId,
+			AppId:           config.AppId,
 		},
 	)
 	return


### PR DESCRIPTION
Add more fields in ConfigPublish
- DeliveryMode
- ReplyTo
- Expiration
- Timestamp
- Type
- UserId
- AppId


```golang
type ConfigPublish struct {
	Exchange        string
	RoutingKey      string
	Mandatory       bool
	Immediate       bool
	Headers         amqp.Table
	ContentType     string
	ContentEncoding string
	Priority        uint8
	CorrelationID   string
	MessageID       string
	DeliveryMode    uint8
	ReplyTo         string
	Expiration      string
	Timestamp       time.Time
	Type            string
	UserId          string
	AppId           string
}
``` 